### PR TITLE
switch to structured logging via debugnyan

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,5 +8,7 @@ services:
       dockerfile: Dockerfile
       args:
         NPM_TOKEN: $NPM_TOKEN
+    environment:
+      - DEBUG=*
     networks:
       - internal

--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -1,4 +1,7 @@
+import debugnyan from 'debugnyan';
 import NodeRSA from 'node-rsa';
+
+const log = debugnyan('transformer-runtime:secrets', {});
 
 export function createDecryptor(key?: string) {
 	const decryptionKey = key
@@ -25,8 +28,8 @@ export function decryptSecrets(
 		return undefined;
 	}
 	if (!decryptionKey) {
-		console.log(
-			`WARN: no secrets key provided! Will pass along secrets without decryption. Should not happen in production`,
+		log.warn(
+			`no secrets key provided! Will pass along secrets without decryption. Should not happen in production`,
 		);
 		return sec;
 	}
@@ -38,7 +41,7 @@ export function decryptSecrets(
 		} else if (typeof val === 'object') {
 			result[key] = exports.decryptSecrets(decryptionKey, val);
 		} else {
-			console.log(`WARN: unknown type in secrets for key ${key}`);
+			log.warn({ key }, `unknown type in secrets for key`);
 		}
 	}
 	return result;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "homepage": "https://github.com/product-os/transformer-runtime#readme",
   "dependencies": {
+    "debugnyan": "^3.0.0",
     "dockerode": "^3.3.0",
     "node-rsa": "^1.1.1"
   },

--- a/test/unit/helpers/validation.spec.ts
+++ b/test/unit/helpers/validation.spec.ts
@@ -1,7 +1,9 @@
+import debugnyan from 'debugnyan';
 import { writeFile } from 'fs/promises';
 import TransformerRuntime from '../../../lib';
 
 const runtime = new TransformerRuntime();
+const defaultLogger = debugnyan('transformer-runtime-tests', {});
 
 describe('Validation', () => {
 	test('Output manifest validation - success', async () => {
@@ -37,6 +39,7 @@ describe('Validation', () => {
 				] as any, // Thanks typescript
 			},
 			'.',
+			defaultLogger,
 		);
 		expect(out).toBe(undefined);
 	});
@@ -75,7 +78,7 @@ describe('Validation', () => {
 				] as any, // Thanks typescript
 			}),
 		);
-		const out = await runtime.createOutputManifest(0, '.');
+		const out = await runtime.createOutputManifest(0, '.', defaultLogger);
 		expect(out.results['0'].artifactPath).toBe('.');
 	});
 });


### PR DESCRIPTION
This will allow filtering logs to individual runs or by commit etc

I wanted a library that does structured logging, can be used in packages AND apps (i.e. doesn't need a global config to be passed down) and can be enabled per package. I decided to go for [`debugnyan`](https://www.npmjs.com/package/debugnyan) as it seems to have at least *some* traction. Other packages I looked at but didn't quite cut it
* https://www.npmjs.com/package/pino no filtering
* https://www.npmjs.com/package/roarr no filtering
* https://www.npmjs.com/package/lugg looks actually pretty nice, but hasn't been touched for three years and has no types
* https://www.npmjs.com/package/tslog overkill and needs global config